### PR TITLE
Initial messages for review.

### DIFF
--- a/jackal_msgs/CMakeLists.txt
+++ b/jackal_msgs/CMakeLists.txt
@@ -6,13 +6,17 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-#add_message_files(
-#  FILES
-#)
+add_message_files(
+  FILES
+  Drive.msg
+  DriveFeedback.msg
+  Feedback.msg
+  Status.msg
+)
 
-#generate_messages(
-#  DEPENDENCIES
-#  std_msgs
-#)
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
 catkin_package(CATKIN_DEPENDS std_msgs message_runtime)

--- a/jackal_msgs/msg/Drive.msg
+++ b/jackal_msgs/msg/Drive.msg
@@ -1,0 +1,12 @@
+# This message represents a low-level motor command to Jackal.
+
+# Command units dependent on the value of this field
+int8 TYPE_SPEED=0   # speed command (rad/s)
+int8 TYPE_PWM=1     # proportion of full voltage command [-1.0..1.0]
+int8 TYPE_TORQUE=2  # torque command (Nm)
+int8 type
+
+# Units as above, +ve direction propels chassis forward.
+int8 LEFT=0
+int8 RIGHT=1
+float32[2] drivers

--- a/jackal_msgs/msg/Drive.msg
+++ b/jackal_msgs/msg/Drive.msg
@@ -4,6 +4,7 @@
 int8 TYPE_SPEED=0   # speed command (rad/s)
 int8 TYPE_PWM=1     # proportion of full voltage command [-1.0..1.0]
 int8 TYPE_TORQUE=2  # torque command (Nm)
+int8 TYPE_NONE=255  # no control, commanded values ignored.
 int8 type
 
 # Units as above, +ve direction propels chassis forward.

--- a/jackal_msgs/msg/DriveFeedback.msg
+++ b/jackal_msgs/msg/DriveFeedback.msg
@@ -1,0 +1,15 @@
+# This message represents feedback data from a single drive unit (driver + motor).
+
+# Current flowing from battery into the MOSFET bridge.
+float32 current
+
+# Temperatures measured in the MOSFET bridge and on the motor casing, in deg C.
+float32 bridge_temperature
+float32 motor_temperature
+
+# Encoder data
+float32 measured_speed   # rad/s
+float64 measured_travel  # rad
+
+# True if the underlying driver chip reports a fault condition.
+bool driver_fault

--- a/jackal_msgs/msg/Feedback.msg
+++ b/jackal_msgs/msg/Feedback.msg
@@ -9,3 +9,10 @@ DriveFeedback[2] drivers
 # Temperatures 
 float32 pcb_temperature
 float32 mcu_temperature
+
+# Commanded control type, use the TYPE_ constants from jackal_msgs/Drive.
+uint8 commanded_type
+
+# Actual control type. This may differ from the commanded in cases where
+# the motor enable is off, the motors are in over-current, etc.
+uint8 actual_type

--- a/jackal_msgs/msg/Feedback.msg
+++ b/jackal_msgs/msg/Feedback.msg
@@ -1,0 +1,11 @@
+# This message represents high-frequency feedback from the MCU,
+# as necessary to support closed-loop control and thermal monitoring.
+# Default publish frequency is 50Hz.
+
+Header header
+
+DriveFeedback[2] drivers
+
+# Temperatures 
+float32 pcb_temperature
+float32 mcu_temperature

--- a/jackal_msgs/msg/Status.msg
+++ b/jackal_msgs/msg/Status.msg
@@ -1,0 +1,28 @@
+# This message represents Jackal's lower-frequency status updates
+# Default publish frequency is 1Hz.
+
+Header header
+
+# Monitoring the stop loop
+bool drivers_active
+bool driver_external_stop_present
+bool driver_external_stop_stopped
+
+# Voltage rails, in volts
+# Averaged over the message period
+float32 measured_battery
+float32 measured_12v
+float32 measured_5v
+
+# Current senses available on platform, in amps.
+# Averaged over the message period
+float32 drive_current
+float32 user_current
+float32 computer_current
+float32 total_current
+
+# Highest total system current peak as measured in a 1ms window.
+float32 total_current_peak
+
+# Integration of all power consumption since MCU power-on, in watt-hours.
+float64 total_power_consumed 

--- a/jackal_msgs/msg/Status.msg
+++ b/jackal_msgs/msg/Status.msg
@@ -3,7 +3,12 @@
 
 Header header
 
-# Monitoring the stop loop
+# Times since MCU power-on and MCU rosserial connection, respectively.
+duration mcu_uptime
+duration connection_uptime
+
+# Monitoring the run/stop loop. Changes in these values trigger an immediate
+# publish, outside the ordinarily-scheduled 1Hz updates.
 bool drivers_active
 bool driver_external_stop_present
 bool driver_external_stop_stopped


### PR DESCRIPTION
Please review, @rgariepy, @ibaranov-cp

Additional MCU msgs/srvs (to be documented on the jackal_firmware ROS wiki page):

nmea_msgs/Sentence -> raw strings to and from globaltop module
sensor_msgs/IMU -> raw data from accelerometer and gyro
geometry_msgs/Vector3Stamped -> raw magnetometer data
std_srvs/Empty -> enable_motors, stop_motors services
std_msgs/Bool (?) -> wifi connected status

MCU parameters to be reviewed separately.
