### PR TITLE
Terminology fixes in Drive message

### DIFF
--- a/jackal_msgs/msg/Drive.msg
+++ b/jackal_msgs/msg/Drive.msg
@@ -1,10 +1,10 @@
 # This message represents a low-level motor command to Jackal.
 
 # Command units dependent on the value of this field
-int8 MODE_SPEED=0   # speed command (rad/s)
-int8 MODE_PWM=1     # proportion of full voltage command [-1.0..1.0]
-int8 MODE_TORQUE=2  # torque command (Nm)
-int8 MODE_NONE=-1   # no control, commanded values ignored.
+int8 MODE_VELOCITY=0   # velocity command (rad/s of wheels)
+int8 MODE_PWM=1        # proportion of full voltage command [-1.0..1.0]
+int8 MODE_EFFORT=2     # torque command (Nm)
+int8 MODE_NONE=-1      # no control, commanded values ignored.
 int8 mode
 
 # Units as above, +ve direction propels chassis forward.


### PR DESCRIPTION
Speed -> Velocity
Torque -> Effort

This message is now aligned with JointState terms, apart from PWM, for
which there is no analogue. I'm planning for a torque_constant parameter, which is the scale factor between user-commanded torque and motor-commanded current.

@rgariepy, this look okay to you?
