### PR TITLE
Add hardware string to Status message.

### DIFF
--- a/jackal_msgs/msg/Status.msg
+++ b/jackal_msgs/msg/Status.msg
@@ -3,6 +3,9 @@
 
 Header header
 
+# Commit of firmware source.
+string hardware_id
+
 # Times since MCU power-on and MCU rosserial connection, respectively.
 duration mcu_uptime
 duration connection_uptime


### PR DESCRIPTION
Adding a string for the firmware to declare an identity for itself— a freeform string initially to be used for the git commit of the firmware loaded. This will be primarily exposed to the user as the `hardware_id` in [diagnostic status messages](http://docs.ros.org/api/diagnostic_msgs/html/msg/DiagnosticStatus.html).

@rgariepy, @abencz to review
