### PR TITLE
control.yaml parameter tweaking for better localization performance

### DIFF
--- a/jackal_control/config/control.yaml
+++ b/jackal_control/config/control.yaml
@@ -9,7 +9,7 @@ jackal_velocity_controller:
   right_wheel: ['front_right_wheel', 'rear_right_wheel']
   publish_rate: 50
   pose_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 0.03]
-  twist_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 0.03]
+  twist_covariance_diagonal: [0.001, 0.001, 0.001, 1000000.0, 1000000.0, 0.03]
   cmd_vel_timeout: 0.25
 
   # Odometry fused with IMU is published by robot_localization, so
@@ -36,18 +36,13 @@ ekf_localization:
   odom0: /jackal_velocity_controller/odom
   odom0_config: [true, true, false,
                  false, false, false,
-                 true, false, false,
+                 true, true, true,
                  false, false, true]
   odom0_differential: true
   imu0: /imu/data
-  #imu0_config: [false, false, false,
-  #              true, true, true,
-  #              true, true, true,
-  #              true, true, true]
-  # Re-enable roll/pitch when the IMU correctly stays level.
   imu0_config: [false, false, false,
-                false, false, true,
                 true, true, true,
-                false, false, true]
+                false, false, false,
+                true, true, true]
   odom_frame: odom
   base_link_frame: base_link

--- a/jackal_control/config/control.yaml
+++ b/jackal_control/config/control.yaml
@@ -44,5 +44,6 @@ ekf_localization:
                 true, true, true,
                 false, false, false,
                 true, true, true]
+  imu0_differential: true
   odom_frame: odom
   base_link_frame: base_link


### PR DESCRIPTION
This should aid in keeping some of the covariances in the output of ekf_localization_node (as reported in the /odometry/filtered topic) from exploding. Relevant changes:
- Changed the twist_covariance_diagonal Z velocity variance to 0.001 and set the configuration for Z velocity to true in odom0_config. The use of large covariances is only necessary when you want the filter to ignore a measurement, but robot_localization lets you use the sensorN_config setting for that. Also, in this case, the Jackal is unlikely to ever attain instantaneous Z velocity, and so it's safe to treat the 0 value in the Twist portion of the  /jackal_velocity_controller/odom message as an actual measurement, and fuse it with the other data. The same is true for Y velocity. Its variance was already small, so I only updated its odom0_config value.
- Re-enabled the IMU. I saw that it was commented out, but it seemed to perform well for me. There is some small amount of rotation when the sim starts, but that is likely due to either (a) the velocity controller or IMU having some bias in its yaw or yaw velocity data, or (b) the gravity and downhill-slope starting point in Gazebo is rotating the robot. I enabled roll, pitch, yaw, and their respective velocities in imu0_config. I also set imu0_differential to true, which will have the effect of making the robot always believe it is starting in a level plane, even if it is on a steep slope. From the robot's point of view, however, this often makes sense. It's important to consider, though, that if the robot starts, for example, with its X-axis pointing directly down the slope, then if it drives down that slope to a flat area, ekf_localization_node will indicate that the robot went straight and then went _up_ an incline. While this may seem non-intuitive, the alternative (i.e., if you turn imu0_differential off) is that the robot will start with its true orientation, but if the IMU's first reporting yaw angle is non-zero, then your robot will not be facing directly down the X axis when it starts. 
