### PR TITLE
Turning off differential integration for IMU-based orientation. 

### DIFF
--- a/jackal_control/config/control.yaml
+++ b/jackal_control/config/control.yaml
@@ -44,6 +44,6 @@ ekf_localization:
                 true, true, true,
                 false, false, false,
                 true, true, true]
-  imu0_differential: true
+  imu0_differential: false
   odom_frame: odom
   base_link_frame: base_link


### PR DESCRIPTION
Discovered bug with differential updating and orientation angles in robot_localization. Turning off the differential setting for the IMU until it is resolved. 
