### PR TITLE
Update calibration.rst in Jackal

### DIFF
--- a/jackal_tutorials/doc/calibration.rst
+++ b/jackal_tutorials/doc/calibration.rst
@@ -62,7 +62,7 @@ into ``$ROS_ETC_DIR``. Once this is done, restart the ROS service to begin using
 
 .. code-block:: bash
 
-    sudo service jackal restart
+    sudo service ros restart
 
 Calibration should be performed when jackal is first received, and any time the platform is modified by adding
 new peripherals. It is also recommended to recalibrate annually as part of seasonal maintenance.


### PR DESCRIPTION
Correcting final step in this to read "sudo service ros restart" instead of "sudo service jackal restart"

Note: "sudo service jackal restart" -> Gives users an error saying that this service does not exist.  --> Reported here: https://clearpathrobotics.zendesk.com/agent/tickets/4536