### PR TITLE
Enable the Clearpath Jackal ROS nodes on Windows

### DIFF
--- a/jackal_description/CMakeLists.txt
+++ b/jackal_description/CMakeLists.txt
@@ -11,6 +11,12 @@ install(DIRECTORY meshes launch urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
+if(WIN32)
+install(PROGRAMS scripts/env_run.bat
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+else()
 install(PROGRAMS scripts/env_run
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+endif()

--- a/jackal_description/launch/description.launch
+++ b/jackal_description/launch/description.launch
@@ -1,8 +1,12 @@
 <launch>
   <arg name="config" default="base" />
+  <!-- fix for oneweek project -->
+  <arg name="env_runner" value="$(eval 'env_run' if not optenv('OS', 'unknown').lower().startswith('windows') else 'env_run.bat')" />
+  <!-- the following seems to work too when in devel space, but not in install_isolated -->
+  <!-- <arg name="env_runner" value="env_run" /> -->
 
   <param name="robot_description"
-         command="$(find jackal_description)/scripts/env_run
+         command="$(find jackal_description)/scripts/$(arg env_runner)
                     $(find jackal_description)/urdf/configs/$(arg config)
                     $(find xacro)/xacro $(find jackal_description)/urdf/jackal.urdf.xacro
                     --inorder" />

--- a/jackal_description/scripts/env_run.bat
+++ b/jackal_description/scripts/env_run.bat
@@ -1,0 +1,24 @@
+@echo off
+REM This simple wrapper allowing us to pass a set of
+REM environment variables to be sourced prior to running
+REM another command. Used in the launch file for setting
+REM robot configurations prior to xacro.
+
+set ENVVARS_FILE=%1
+
+REM get arguments starting from %2
+shift
+set RUNNER_COMMAND=
+:getrunnerloop
+if "%1"=="" goto after_loop
+if "%RUNNER_COMMAND%" == "" (
+    set RUNNER_COMMAND=%1
+) else (
+    set RUNNER_COMMAND=%RUNNER_COMMAND% %1
+)
+shift
+goto getrunnerloop
+
+:after_loop
+call %ENVVARS_FILE%
+call %RUNNER_COMMAND%

--- a/jackal_description/scripts/env_run.bat
+++ b/jackal_description/scripts/env_run.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal
 REM This simple wrapper allowing us to pass a set of
 REM environment variables to be sourced prior to running
 REM another command. Used in the launch file for setting

--- a/jackal_description/urdf/accessories.urdf.xacro
+++ b/jackal_description/urdf/accessories.urdf.xacro
@@ -17,8 +17,8 @@
   <xacro:include filename="$(find jackal_description)/urdf/accessories/bridge_plate.urdf.xacro" />
 
   <!-- If enabled, generate the LASER payload (by default, a SICK LMS111). -->
-  <xacro:include filename="$(find jackal_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro" />
   <xacro:if value="$(optenv JACKAL_LASER 0)">
+    <xacro:include filename="$(find jackal_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro" />
     <sick_lms1xx_mount prefix="$(optenv JACKAL_LASER_MOUNT front)"
                        topic="$(optenv JACKAL_LASER_TOPIC front/scan)"/>
 
@@ -31,8 +31,8 @@
   </xacro:if>
 
   <!-- If enabled, generate the upgraded Navsat payload (a Novatel Smart6). -->
-  <xacro:include filename="$(find jackal_description)/urdf/accessories/novatel_smart6.urdf.xacro" />
   <xacro:if value="$(optenv JACKAL_NAVSAT 0)">
+    <xacro:include filename="$(find jackal_description)/urdf/accessories/novatel_smart6.urdf.xacro" />
     <bridge_plate mount="$(optenv JACKAL_NAVSAT_MOUNT rear)"
                   height="$(optenv JACKAL_NAVSAT_HEIGHT 0.1)" />
     <novatel_smart6 prefix="$(optenv JACKAL_NAVSAT_MOUNT rear)"/>
@@ -125,8 +125,8 @@
     </joint>
   </xacro:if> -->
 
-  <xacro:include filename="$(find jackal_description)/urdf/accessories/hokuyo_ust10.urdf.xacro" />
   <xacro:if value="$(optenv JACKAL_FRONT_ACCESSORY_FENDER 0)">
+    <xacro:include filename="$(find jackal_description)/urdf/accessories/hokuyo_ust10.urdf.xacro" />
     <xacro:if value="$(optenv JACKAL_FRONT_FENDER_UST10 0)">
         <hokuyo_ust10 prefix="front_ust10" parent_link="front_fender_accessory_link"/>
     </xacro:if>

--- a/jackal_description/urdf/configs/base.bat
+++ b/jackal_description/urdf/configs/base.bat
@@ -1,0 +1,5 @@
+@echo off
+
+REM The base Jackal configuration has no accessories at all,
+REM so nothing need be specified here; the defaults as given
+REM in the URDF suffice to define this config.

--- a/jackal_description/urdf/configs/front_bumblebee2.bat
+++ b/jackal_description/urdf/configs/front_bumblebee2.bat
@@ -1,0 +1,3 @@
+@echo off
+
+set JACKAL_BB2=1

--- a/jackal_description/urdf/configs/front_flea3.bat
+++ b/jackal_description/urdf/configs/front_flea3.bat
@@ -1,0 +1,3 @@
+@echo off
+
+set JACKAL_FLEA3=1

--- a/jackal_description/urdf/configs/front_laser.bat
+++ b/jackal_description/urdf/configs/front_laser.bat
@@ -1,0 +1,8 @@
+@echo off
+
+REM The front_laser configuration of Jackal is sufficient for
+REM basic gmapping and navigation. It is mostly the default
+REM config, but with a SICK LMS100 series LIDAR on the front,
+REM pointing forward.
+
+set JACKAL_LASER=1


### PR DESCRIPTION
This change introduces a ROS on Windows compatibility to the Clearpath Jackal. 