### PR TITLE
Improve out-of-the-box support for the Hokuyo UST10

### DIFF
--- a/jackal_description/urdf/accessories.urdf.xacro
+++ b/jackal_description/urdf/accessories.urdf.xacro
@@ -18,16 +18,31 @@
 
   <!-- If enabled, generate the LASER payload (by default, a SICK LMS111). -->
   <xacro:if value="$(optenv JACKAL_LASER 0)">
-    <xacro:include filename="$(find jackal_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro" />
-    <sick_lms1xx_mount prefix="$(optenv JACKAL_LASER_MOUNT front)"
-                       topic="$(optenv JACKAL_LASER_TOPIC front/scan)"/>
+    <xacro:if value="$(optenv JACKAL_LASER_HOKUYO 0)">
+      <xacro:include filename="$(find jackal_description)/urdf/accessories/hokuyo_ust10.urdf.xacro" />
+      <hokuyo_ust10_mount prefix="$(optenv JACKAL_LASER_MOUNT front)"
+                          topic="$(optenv JACKAL_LASER_TOPIC front/scan)" />
+              
+      <joint name="$(optenv JACKAL_LASER_MOUNT front)_laser_mount_joint" type="fixed">
+        <origin xyz="$(optenv JACKAL_LASER_OFFSET 0.11 0 0)"
+                rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
+        <parent link="$(optenv JACKAL_LASER_MOUNT front)_mount" />
+        <child link="$(optenv JACKAL_LASER_MOUNT front)_laser_mount" />
+      </joint>
+    </xacro:if>
+    
+    <xacro:unless value="$(optenv JACKAL_LASER_HOKUYO 0)">
+      <xacro:include filename="$(find jackal_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro" />
+      <sick_lms1xx_mount prefix="$(optenv JACKAL_LASER_MOUNT front)"
+                         topic="$(optenv JACKAL_LASER_TOPIC front/scan)"/>
 
-    <joint name="$(optenv JACKAL_LASER_MOUNT front)_laser_mount_joint" type="fixed">
-      <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
-              rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
-      <parent link="$(optenv JACKAL_LASER_MOUNT front)_mount" />
-      <child link="$(optenv JACKAL_LASER_MOUNT front)_laser_mount" />
-    </joint>
+      <joint name="$(optenv JACKAL_LASER_MOUNT front)_laser_mount_joint" type="fixed">
+        <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
+                rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
+        <parent link="$(optenv JACKAL_LASER_MOUNT front)_mount" />
+        <child link="$(optenv JACKAL_LASER_MOUNT front)_laser_mount" />
+      </joint>
+    </xacro:unless>
   </xacro:if>
 
   <!-- If enabled, generate the upgraded Navsat payload (a Novatel Smart6). -->

--- a/jackal_description/urdf/accessories/hokuyo_ust10.urdf.xacro
+++ b/jackal_description/urdf/accessories/hokuyo_ust10.urdf.xacro
@@ -1,26 +1,71 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="hokuyo_ust10" params="prefix parent_link">
+  <xacro:macro name="hokuyo_ust10_mount" params="prefix topic">
+
+    <xacro:macro name="hokuyo_ust10" params="frame:=laser topic:=scan sample_size:=720 update_rate:=50
+               min_angle:=-2.35619 max_angle:=2.35619 min_range:=0.1 max_range:=30.0 robot_namespace:=/">
+      <link name="${frame}">
+        <inertial>
+          <mass value="1.1" />
+          <origin xyz="0 0 0" />
+          <inertia ixx="${0.0833333 * 1.1 * (0.102*0.102 + 0.152*0.152)}" ixy="0.0" ixz="0.0"
+            iyy="${0.0833333 * 1.1 * (0.105*0.105 + 0.152*0.152)}" iyz="0.0"
+            izz="${0.0833333 * 1.1 * (0.105*0.105 + 0.102*0.102)}" />
+        </inertial>
+      </link>
+
+      <gazebo reference="${frame}">
+        <turnGravityOff>true</turnGravityOff>
+        <sensor type="ray" name="${frame}">
+          <pose>0 0 0 0 0 0</pose>
+          <visualize>false</visualize>
+          <update_rate>${update_rate}</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>${sample_size}</samples>
+                <resolution>1</resolution>
+                <min_angle>${min_angle}</min_angle>
+                <max_angle>${max_angle}</max_angle>
+              </horizontal>
+            </scan>
+            <range>
+              <min>${min_range}</min>
+              <max>${max_range}</max>
+              <resolution>0.01</resolution>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>0.001</stddev>
+            </noise>
+          </ray>
+          <plugin name="gazebo_ros_laser" filename="libgazebo_ros_laser.so">
+            <topicName>${topic}</topicName>
+            <frameName>${frame}</frameName>
+            <robotNamespace>${robot_namespace}</robotNamespace>
+          </plugin>
+        </sensor>
+      </gazebo>
+    </xacro:macro>
+
+
+    <hokuyo_ust10 frame="${prefix}_laser" topic="${topic}" />
 
     <link name="${prefix}_laser_mount">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
+          <!-- Origin of this mesh is the base of the bracket. -->
           <mesh filename="package://jackal_description/meshes/hokuyo_ust10.stl" />
         </geometry>
         <material name="dark_grey" />
       </visual>
     </link>
 
-    <joint name="${prefix}_laser_mount_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="${parent_link}" />
-      <child link="${prefix}_laser_mount" />
-    </joint>
-
-    <link name="${prefix}_laser" />
     <joint name="${prefix}_laser_joint" type="fixed">
-      <origin xyz="0 0 0.0474" rpy="0 0 0" />
+      <!-- This offset is from the base of the bracket to the LIDAR's focal point. -->
+      <origin xyz="0 0 0.149" rpy="0 0 0" />
       <parent link="${prefix}_laser_mount" />
       <child link="${prefix}_laser" />
     </joint>
@@ -28,7 +73,7 @@
     <gazebo reference="${prefix}_laser_mount">
       <material>Gazebo/DarkGrey</material>
     </gazebo>
-
+    
   </xacro:macro>
 
 </robot>


### PR DESCRIPTION
Modify the Hokuyo accessory URDF so that it works properly in gazebo/rviz. Add an additional environment var "JACKAL_LASER_HOKUYO" which overrides the default lms1xx sensor with the ust10.