### PR TITLE
fixed ps4 reference for configuration loading

### DIFF
--- a/jackal_control/launch/teleop.launch
+++ b/jackal_control/launch/teleop.launch
@@ -4,8 +4,9 @@
 
   <group ns="bluetooth_teleop" if="$(arg joystick)">
 
-    <group unless="$(optenv JACKAL_PS3 0)" >
+    <group unless="$(optenv JACKAL_PS4 0)" >
       <rosparam command="load" file="$(find jackal_control)/config/teleop_ps4.yaml" />
+      <param name="joy_node/dev" value="$(arg joy_dev)" />    
     </group>
 
     <group if="$(optenv JACKAL_PS3 0)" >


### PR DESCRIPTION
Resolves issue with PS4 controller configuration getting loaded correctly with JACKAL_PS4 environment variable.  Current behavior only loads PS3 configuration and will cause erroneous behavior for button mappings that are not shared with PS4 configuration.

I am unsure if the following line is needed and added it anyways to match ps3 code:

```<param name="joy_node/dev" value="$(arg joy_dev)" />```