### PR TITLE
Use joy_dev argument for PS4 controllers

### DIFF
--- a/jackal_control/config/teleop_ps4.yaml
+++ b/jackal_control/config/teleop_ps4.yaml
@@ -10,4 +10,3 @@ teleop_twist_joy:
 joy_node:
   deadzone: 0.1
   autorepeat_rate: 20
-  dev: /dev/input/ps4

--- a/jackal_control/launch/teleop.launch
+++ b/jackal_control/launch/teleop.launch
@@ -6,6 +6,7 @@
 
     <group unless="$(optenv JACKAL_PS3 0)" >
       <rosparam command="load" file="$(find jackal_control)/config/teleop_ps4.yaml" />
+      <param name="joy_node/dev" value="$(arg joy_dev)" />
     </group>
 
     <group if="$(optenv JACKAL_PS3 0)" >


### PR DESCRIPTION
see: https://github.com/jackal/jackal/issues/70

Short version: the joy_dev argument in the teleop.launch file is ignored unless JACKAL_PS3 is enabled.  If a user-configured machine has different/missing udev rules, or has a non-standard controller that uses the same button mappings as the PS4 controller the joy_dev argument may be required.