### PR TITLE
Use env vars for the scan topic defaults

### DIFF
--- a/jackal_navigation/launch/amcl_demo.launch
+++ b/jackal_navigation/launch/amcl_demo.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <arg name="use_map_topic" default="false"/>
-  <arg name="scan_topic" default="front/scan" />
+  <arg name="scan_topic" default="$(eval optenv('JACKAL_LASER_TOPIC', 'front/scan'))" />
 
   <!-- Run the map server -->
  <arg name="map_file" default="$(find jackal_navigation)/maps/jackal_race.yaml"/>

--- a/jackal_navigation/launch/gmapping_demo.launch
+++ b/jackal_navigation/launch/gmapping_demo.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="scan_topic"      default="front/scan" />
+  <arg name="scan_topic" default="$(eval optenv('JACKAL_LASER_TOPIC', 'front/scan'))" />
 
   <!--- Run gmapping -->
   <include file="$(find jackal_navigation)/launch/include/gmapping.launch">

--- a/jackal_navigation/launch/include/amcl.launch
+++ b/jackal_navigation/launch/include/amcl.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <arg name="use_map_topic" default="false"/>
-  <arg name="scan_topic" default="front/scan" />
+  <arg name="scan_topic" default="$(eval optenv('JACKAL_LASER_TOPIC', 'front/scan'))" />
 
   <node pkg="amcl" type="amcl" name="amcl">
     <param name="use_map_topic" value="$(arg use_map_topic)"/>

--- a/jackal_navigation/launch/include/gmapping.launch
+++ b/jackal_navigation/launch/include/gmapping.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="scan_topic" default="front/scan" />
+  <arg name="scan_topic" default="$(eval optenv('JACKAL_LASER_TOPIC', 'front/scan'))" />
 
   <node pkg="gmapping" type="slam_gmapping" name="slam_gmapping" output="screen">
 


### PR DESCRIPTION
Use the JACKAL_LASER_TOPIC env var as the default for the scan topic in amcl + gmapping demos