### PR TITLE
Load the control extras last

### DIFF
--- a/jackal_control/launch/control.launch
+++ b/jackal_control/launch/control.launch
@@ -4,10 +4,6 @@
 
   <rosparam command="load" file="$(find jackal_control)/config/control.yaml" />
 
-  <group if="$(optenv JACKAL_CONTROL_EXTRAS 0)" >
-    <rosparam command="load" file="$(env JACKAL_CONTROL_EXTRAS_PATH)" />
-  </group>
-
   <node name="controller_spawner" pkg="controller_manager" type="spawner"
         args="jackal_joint_publisher jackal_velocity_controller" />
 
@@ -21,5 +17,9 @@
     <rosparam command="load" file="$(find jackal_control)/config/twist_mux.yaml" />
     <remap from="cmd_vel_out" to="jackal_velocity_controller/cmd_vel"/>
   </node>
+
+  <group if="$(optenv JACKAL_CONTROL_EXTRAS 0)" >
+    <rosparam command="load" file="$(env JACKAL_CONTROL_EXTRAS_PATH)" />
+  </group>
 
 </launch>


### PR DESCRIPTION
This should fix a bug where e.g. overriding the IMU topic for EKF wasn't applied correctly.

Integration will be using this in the very-near-future, so once this change is merged we should probably re-bloom ASAP.