### PR TITLE
Add VLP16 support, refactor main/secondary laser envar support

### DIFF
--- a/jackal_description/package.xml
+++ b/jackal_description/package.xml
@@ -17,6 +17,7 @@
   <run_depend>xacro</run_depend>
   <run_depend>lms1xx</run_depend>
   <run_depend>pointgrey_camera_description</run_depend>
+  <run_depend>velodyne_description</run_depend>
 
   <export>
   </export>

--- a/jackal_description/urdf/accessories.urdf.xacro
+++ b/jackal_description/urdf/accessories.urdf.xacro
@@ -18,7 +18,7 @@
 
   <xacro:include filename="$(find jackal_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro" />
   <xacro:include filename="$(find jackal_description)/urdf/accessories/hokuyo_ust10.urdf.xacro" />
-  <xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro" />
+  <xacro:include filename="$(find jackal_description)/urdf/accessories/vlp16_mount.urdf.xacro" />
 
   <!--
     Add primary/secondary 2D lidar sensors.  By default these are SICK LMS1xx but can be changed with the
@@ -77,9 +77,12 @@
   <xacro:if value="$(optenv JACKAL_LASER_3D 0)">
     <xacro:property name="lidar_3d_model" value="$(optenv JACKAL_LASER_3D_MODEL vlp16)" />
     <xacro:if value="${lidar_3d_model == 'vlp16'}">
-      <xacro:VLP-16 parent="$(optenv JACKAL_LASER_3D_MOUNT front)_mount" topic="$(optenv JACKAL_LASER_3D_TOPIC front/points)">
+      <xacro:vlp16_mount
+          parent_link="$(optenv JACKAL_LASER_3D_MOUNT front)_mount"
+          prefix="$(optenv JACKAL_LASER_3D_MOUNT front)"
+          topic="$(optenv JACKAL_LASER_3D_TOPIC front/points)">
         <origin xyz="$(optenv JACKAL_LASER_3D_OFFSET 0 0 0)" rpy="$(optenv JACKAL_LASER_3D_RPY 0 0 0)" />
-      </xacro:VLP-16>
+      </xacro:vlp16_mount>
     </xacro:if>
   </xacro:if>
 

--- a/jackal_description/urdf/accessories.urdf.xacro
+++ b/jackal_description/urdf/accessories.urdf.xacro
@@ -33,9 +33,9 @@
       <xacro:sick_lms1xx_mount prefix="$(optenv JACKAL_LASER_MOUNT front)"
            parent_link="$(optenv JACKAL_LASER_MOUNT front)_mount"
            topic="$(optenv JACKAL_LASER_TOPIC front/scan)">
-           <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
+        <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
                    rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
-         </xacro:sick_lms1xx_mount>
+      </xacro:sick_lms1xx_mount>
     </xacro:if>
 
     <xacro:if value="${lidar_model == 'ust10'}">
@@ -43,9 +43,9 @@
       <xacro:hokuyo_ust10_mount prefix="$(optenv JACKAL_LASER_MOUNT front)"
           parent_link="$(optenv JACKAL_LASER_MOUNT front)_mount"
           topic="$(optenv JACKAL_LASER_TOPIC front/scan)">
-          <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
-                  rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
-        </xacro:hokuyo_ust10_mount>
+        <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
+                rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
+      </xacro:hokuyo_ust10_mount>
     </xacro:if>
   </xacro:if>
   <xacro:if value="$(optenv JACKAL_LASER_SECONDARY 0)">
@@ -54,18 +54,18 @@
       <xacro:sick_lms1xx_mount prefix="$(optenv JACKAL_LASER_SECONDARY_MOUNT rear)"
            parent_link="$(optenv JACKAL_LASER_SECONDARY_MOUNT rear)_mount"
            topic="$(optenv JACKAL_LASER_SECONDARY_TOPIC rear/scan)">
-           <origin xyz="$(optenv JACKAL_LASER_SECONDARY_OFFSET 0 0 0)"
-                   rpy="$(optenv JACKAL_LASER_SECONDARY_RPY 0 0 3.14159)" />
-         </xacro:sick_lms1xx_mount>
+         <origin xyz="$(optenv JACKAL_LASER_SECONDARY_OFFSET 0 0 0)"
+                 rpy="$(optenv JACKAL_LASER_SECONDARY_RPY 0 0 3.14159)" />
+       </xacro:sick_lms1xx_mount>
     </xacro:if>
 
     <xacro:if value="${lidar2_model == 'ust10'}">
       <xacro:hokuyo_ust10_mount prefix="$(optenv JACKAL_LASER_SECONDARY_MOUNT rear)"
           parent_link="$(optenv JACKAL_LASER_SECONDARY_MOUNT rear)_mount"
           topic="$(optenv JACKAL_LASER_SECONDARY_TOPIC rear/scan)">
-          <origin xyz="$(optenv JACKAL_LASER_SECONDARY_OFFSET 0 0 0)"
-                  rpy="$(optenv JACKAL_LASER_SECONDARY_RPY 0 0 3.14159)" />
-        </xacro:hokuyo_ust10_mount>
+        <origin xyz="$(optenv JACKAL_LASER_SECONDARY_OFFSET 0 0 0)"
+                rpy="$(optenv JACKAL_LASER_SECONDARY_RPY 0 0 3.14159)" />
+      </xacro:hokuyo_ust10_mount>
     </xacro:if>
   </xacro:if>
 

--- a/jackal_description/urdf/accessories.urdf.xacro
+++ b/jackal_description/urdf/accessories.urdf.xacro
@@ -16,21 +16,71 @@
   <!-- This optional plate mounts both the upgraded GPS and the Velodyne 3D LIDAR. -->
   <xacro:include filename="$(find jackal_description)/urdf/accessories/bridge_plate.urdf.xacro" />
 
-  <!-- If enabled, generate the LASER payload (by default, a SICK LMS111). -->
-  <xacro:if value="$(optenv JACKAL_LASER 0)">
-    <xacro:if value="$(optenv JACKAL_LASER_HOKUYO 0)">
-      <xacro:include filename="$(find jackal_description)/urdf/accessories/hokuyo_ust10.urdf.xacro" />
-      <xacro:hokuyo_ust10_mount prefix="$(optenv JACKAL_LASER_MOUNT front)"
-                          parent_link="$(optenv JACKAL_LASER_MOUNT front)_mount"
-                          topic="$(optenv JACKAL_LASER_TOPIC front/scan)" />
-    </xacro:if>
+  <xacro:include filename="$(find jackal_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro" />
+  <xacro:include filename="$(find jackal_description)/urdf/accessories/hokuyo_ust10.urdf.xacro" />
+  <xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro" />
 
-    <xacro:unless value="$(optenv JACKAL_LASER_HOKUYO 0)">
+  <!--
+    Add primary/secondary 2D lidar sensors.  By default these are SICK LMS1xx but can be changed with the
+    JACKAL_LASER_MODEL and JACKAL_LASER2_MODEL environment variables. Valid model designations are:
+    - lms1xx (default) :: SICK LMS1xx
+    - ust10            :: Hokuyo UST10
+  -->
+  <xacro:if value="$(optenv JACKAL_LASER 0)">
+    <xacro:property name="lidar_model" value="$(optenv JACKAL_LASER_MODEL lms1xx)" />
+    <xacro:if value="${lidar_model == 'lms1xx'}">
       <xacro:include filename="$(find jackal_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro" />
       <xacro:sick_lms1xx_mount prefix="$(optenv JACKAL_LASER_MOUNT front)"
-                         parent_link="$(optenv JACKAL_LASER_MOUNT front)_mount"
-                         topic="$(optenv JACKAL_LASER_TOPIC front/scan)"/>
-    </xacro:unless>
+           parent_link="$(optenv JACKAL_LASER_MOUNT front)_mount"
+           topic="$(optenv JACKAL_LASER_TOPIC front/scan)">
+           <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
+                   rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
+         </xacro:sick_lms1xx_mount>
+    </xacro:if>
+
+    <xacro:if value="${lidar_model == 'ust10'}">
+      <xacro:include filename="$(find jackal_description)/urdf/accessories/hokuyo_ust10.urdf.xacro" />
+      <xacro:hokuyo_ust10_mount prefix="$(optenv JACKAL_LASER_MOUNT front)"
+          parent_link="$(optenv JACKAL_LASER_MOUNT front)_mount"
+          topic="$(optenv JACKAL_LASER_TOPIC front/scan)">
+          <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
+                  rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
+        </xacro:hokuyo_ust10_mount>
+    </xacro:if>
+  </xacro:if>
+  <xacro:if value="$(optenv JACKAL_LASER2 0)">
+    <xacro:property name="lidar2_model" value="$(optenv JACKAL_LASER2_MODEL lms1xx)" />
+    <xacro:if value="${lidar2_model == 'lms1xx'}">
+      <xacro:sick_lms1xx_mount prefix="$(optenv JACKAL_LASER2_MOUNT rear)"
+           parent_link="$(optenv JACKAL_LASER2_MOUNT rear)_mount"
+           topic="$(optenv JACKAL_LASER2_TOPIC rear/scan)">
+           <origin xyz="$(optenv JACKAL_LASER2_OFFSET 0 0 0)"
+                   rpy="$(optenv JACKAL_LASER2_RPY 0 0 3.14159)" />
+         </xacro:sick_lms1xx_mount>
+    </xacro:if>
+
+    <xacro:if value="${lidar2_model == 'ust10'}">
+      <xacro:hokuyo_ust10_mount prefix="$(optenv JACKAL_LASER2_MOUNT rear)"
+          parent_link="$(optenv JACKAL_LASER2_MOUNT rear)_mount"
+          topic="$(optenv JACKAL_LASER2_TOPIC rear/scan)">
+          <origin xyz="$(optenv JACKAL_LASER2_OFFSET 0 0 0)"
+                  rpy="$(optenv JACKAL_LASER2_RPY 0 0 3.14159)" />
+        </xacro:hokuyo_ust10_mount>
+    </xacro:if>
+  </xacro:if>
+
+  <!--
+    Add a 3D lidar sensor.  By default this is a Velodyne VLP16 but can be changed with the
+    JACKAL_LASER_3D_MODEL environment variable. Valid model designations are:
+    - vlp16 (default)  :: Velodyne VLP16
+  -->
+  <xacro:if value="$(optenv JACKAL_LASER_3D 0)">
+    <xacro:property name="lidar_3d_model" value="$(optenv JACKAL_LASER_3D_MODEL vlp16)" />
+    <xacro:if value="${lidar_3d_model == 'vlp16'}">
+      <xacro:VLP-16 parent="$(optenv JACKAL_LASER_3D_MOUNT front)_mount" topic="$(optenv JACKAL_LASER_3D_TOPIC front/points)">
+        <origin xyz="$(optenv JACKAL_LASER_3D_OFFSET 0 0 0)" rpy="$(optenv JACKAL_LASER_3D_RPY 0 0 0)" />
+      </xacro:VLP-16>
+    </xacro:if>
   </xacro:if>
 
   <!-- If enabled, generate the upgraded Navsat payload (a Novatel Smart6). -->

--- a/jackal_description/urdf/accessories.urdf.xacro
+++ b/jackal_description/urdf/accessories.urdf.xacro
@@ -22,7 +22,7 @@
 
   <!--
     Add primary/secondary 2D lidar sensors.  By default these are SICK LMS1xx but can be changed with the
-    JACKAL_LASER_MODEL and JACKAL_LASER2_MODEL environment variables. Valid model designations are:
+    JACKAL_LASER_MODEL and JACKAL_LASER_SECONDARY_MODEL environment variables. Valid model designations are:
     - lms1xx (default) :: SICK LMS1xx
     - ust10            :: Hokuyo UST10
   -->
@@ -48,23 +48,23 @@
         </xacro:hokuyo_ust10_mount>
     </xacro:if>
   </xacro:if>
-  <xacro:if value="$(optenv JACKAL_LASER2 0)">
-    <xacro:property name="lidar2_model" value="$(optenv JACKAL_LASER2_MODEL lms1xx)" />
+  <xacro:if value="$(optenv JACKAL_LASER_SECONDARY 0)">
+    <xacro:property name="lidar2_model" value="$(optenv JACKAL_LASER_SECONDARY_MODEL lms1xx)" />
     <xacro:if value="${lidar2_model == 'lms1xx'}">
-      <xacro:sick_lms1xx_mount prefix="$(optenv JACKAL_LASER2_MOUNT rear)"
-           parent_link="$(optenv JACKAL_LASER2_MOUNT rear)_mount"
-           topic="$(optenv JACKAL_LASER2_TOPIC rear/scan)">
-           <origin xyz="$(optenv JACKAL_LASER2_OFFSET 0 0 0)"
-                   rpy="$(optenv JACKAL_LASER2_RPY 0 0 3.14159)" />
+      <xacro:sick_lms1xx_mount prefix="$(optenv JACKAL_LASER_SECONDARY_MOUNT rear)"
+           parent_link="$(optenv JACKAL_LASER_SECONDARY_MOUNT rear)_mount"
+           topic="$(optenv JACKAL_LASER_SECONDARY_TOPIC rear/scan)">
+           <origin xyz="$(optenv JACKAL_LASER_SECONDARY_OFFSET 0 0 0)"
+                   rpy="$(optenv JACKAL_LASER_SECONDARY_RPY 0 0 3.14159)" />
          </xacro:sick_lms1xx_mount>
     </xacro:if>
 
     <xacro:if value="${lidar2_model == 'ust10'}">
-      <xacro:hokuyo_ust10_mount prefix="$(optenv JACKAL_LASER2_MOUNT rear)"
-          parent_link="$(optenv JACKAL_LASER2_MOUNT rear)_mount"
-          topic="$(optenv JACKAL_LASER2_TOPIC rear/scan)">
-          <origin xyz="$(optenv JACKAL_LASER2_OFFSET 0 0 0)"
-                  rpy="$(optenv JACKAL_LASER2_RPY 0 0 3.14159)" />
+      <xacro:hokuyo_ust10_mount prefix="$(optenv JACKAL_LASER_SECONDARY_MOUNT rear)"
+          parent_link="$(optenv JACKAL_LASER_SECONDARY_MOUNT rear)_mount"
+          topic="$(optenv JACKAL_LASER_SECONDARY_TOPIC rear/scan)">
+          <origin xyz="$(optenv JACKAL_LASER_SECONDARY_OFFSET 0 0 0)"
+                  rpy="$(optenv JACKAL_LASER_SECONDARY_RPY 0 0 3.14159)" />
         </xacro:hokuyo_ust10_mount>
     </xacro:if>
   </xacro:if>

--- a/jackal_description/urdf/accessories.urdf.xacro
+++ b/jackal_description/urdf/accessories.urdf.xacro
@@ -78,9 +78,9 @@
     <xacro:property name="lidar_3d_model" value="$(optenv JACKAL_LASER_3D_MODEL vlp16)" />
     <xacro:if value="${lidar_3d_model == 'vlp16'}">
       <xacro:vlp16_mount
-          parent_link="$(optenv JACKAL_LASER_3D_MOUNT front)_mount"
-          prefix="$(optenv JACKAL_LASER_3D_MOUNT front)"
-          topic="$(optenv JACKAL_LASER_3D_TOPIC front/points)">
+          parent_link="$(optenv JACKAL_LASER_3D_MOUNT mid)_mount"
+          prefix="$(optenv JACKAL_LASER_3D_MOUNT mid)"
+          topic="$(optenv JACKAL_LASER_3D_TOPIC mid/points)">
         <origin xyz="$(optenv JACKAL_LASER_3D_OFFSET 0 0 0)" rpy="$(optenv JACKAL_LASER_3D_RPY 0 0 0)" />
       </xacro:vlp16_mount>
     </xacro:if>

--- a/jackal_description/urdf/accessories/hokuyo_ust10.urdf.xacro
+++ b/jackal_description/urdf/accessories/hokuyo_ust10.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="hokuyo_ust10_mount" params="prefix topic parent_link">
+  <xacro:macro name="hokuyo_ust10_mount" params="prefix topic parent_link *origin">
 
     <xacro:macro name="hokuyo_ust10" params="frame:=laser topic:=scan sample_size:=720 update_rate:=50
                min_angle:=-2.35619 max_angle:=2.35619 min_range:=0.1 max_range:=30.0 robot_namespace:=/">
@@ -52,8 +52,7 @@
     <xacro:hokuyo_ust10 frame="${prefix}_laser" topic="${topic}"/>
 
     <joint name="${prefix}_laser_mount_joint" type="fixed">
-      <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
-              rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent_link}" />
       <child link="${prefix}_laser_mount" />
     </joint>

--- a/jackal_description/urdf/accessories/sick_lms1xx_mount.urdf.xacro
+++ b/jackal_description/urdf/accessories/sick_lms1xx_mount.urdf.xacro
@@ -31,13 +31,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   <xacro:include filename="$(find lms1xx)/urdf/sick_lms1xx.urdf.xacro" />
 
-  <xacro:macro name="sick_lms1xx_mount" params="prefix topic parent_link">
+  <xacro:macro name="sick_lms1xx_mount" params="prefix topic parent_link *origin">
 
     <xacro:sick_lms1xx frame="${prefix}_laser" topic="${topic}" />
 
     <joint name="${prefix}_laser_mount_joint" type="fixed">
-      <origin xyz="$(optenv JACKAL_LASER_OFFSET 0 0 0)"
-              rpy="$(optenv JACKAL_LASER_RPY 0 0 0)" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent_link}" />
       <child link="${prefix}_laser_mount" />
     </joint>

--- a/jackal_description/urdf/accessories/vlp16_mount.urdf.xacro
+++ b/jackal_description/urdf/accessories/vlp16_mount.urdf.xacro
@@ -1,0 +1,98 @@
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro" />
+
+  <xacro:macro name="vlp16_mount" params="prefix parent_link topic height:=0.1 *origin">
+    <link name="${prefix}_vlp16_mount" />
+
+    <link name="${prefix}_vlp16_plate">
+      <visual>
+        <geometry>
+          <box size="0.1 0.1 0.002" />
+        </geometry>
+        <material name="black" />
+        <origin xyz="0 0 -0.001" rpy="0 0 0" />
+      </visual>
+    </link>
+
+    <link name="${prefix}_vlp16_leg1">
+      <visual>
+        <geometry>
+          <cylinder length="${height}" radius="0.003" />
+        </geometry>
+        <material name="white">
+          <color rgba="1 1 1 1" />
+        </material>
+        <origin xyz="0 0 ${height/2}" rpy="0 0 0" />
+      </visual>
+    </link>
+    <link name="${prefix}_vlp16_leg2">
+      <visual>
+        <geometry>
+          <cylinder length="${height}" radius="0.003" />
+        </geometry>
+        <material name="white">
+          <color rgba="1 1 1 1" />
+        </material>
+        <origin xyz="0 0 ${height/2}" rpy="0 0 0" />
+      </visual>
+    </link>
+    <link name="${prefix}_vlp16_leg3">
+      <visual>
+        <geometry>
+          <cylinder length="${height}" radius="0.003" />
+        </geometry>
+        <material name="white">
+          <color rgba="1 1 1 1" />
+        </material>
+        <origin xyz="0 0 ${height/2}" rpy="0 0 0" />
+      </visual>
+    </link>
+    <link name="${prefix}_vlp16_leg4">
+      <visual>
+        <geometry>
+          <cylinder length="${height}" radius="0.003" />
+        </geometry>
+        <material name="white">
+          <color rgba="1 1 1 1" />
+        </material>
+        <origin xyz="0 0 ${height/2}" rpy="0 0 0" />
+      </visual>
+    </link>
+
+    <joint name="${prefix}_vlp16_mount_joint" type="fixed">
+      <parent link="${parent_link}" />
+      <child link="${prefix}_vlp16_mount" />
+      <xacro:insert_block name="origin" />
+    </joint>
+
+    <joint name="${prefix}_vlp16_leg1_joint" type="fixed">
+      <parent link="${prefix}_mount" />
+      <child link="${prefix}_vlp16_leg1" />
+      <origin xyz="0.05 0.05 0" rpy="0 0 0" />
+    </joint>
+    <joint name="${prefix}_vlp16_leg2_joint" type="fixed">
+      <parent link="${prefix}_mount" />
+      <child link="${prefix}_vlp16_leg2" />
+      <origin xyz="0.05 -0.05 0" rpy="0 0 0" />
+    </joint>
+    <joint name="${prefix}_vlp16_leg3_joint" type="fixed">
+      <parent link="${prefix}_mount" />
+      <child link="${prefix}_vlp16_leg3" />
+      <origin xyz="-0.05 0.05 0" rpy="0 0 0" />
+    </joint>
+    <joint name="${prefix}_vlp16_leg4_joint" type="fixed">
+      <parent link="${prefix}_mount" />
+      <child link="${prefix}_vlp16_leg4" />
+      <origin xyz="-0.05 -0.05 0" rpy="0 0 0" />
+    </joint>
+    <joint name="${prefix}_vlp16_plate_joint" type="fixed">
+      <parent link="${prefix}_vlp16_mount" />
+      <child link="${prefix}_vlp16_plate" />
+      <origin xyz="0 0 ${height}" rpy="0 0 0" />
+    </joint>
+
+    <xacro:VLP-16 parent="${prefix}_vlp16_plate" topic="${topic}">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:VLP-16>
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
This depends on a similar PR in jackal_robot.

Main features:
- remove JACKAL_LASER_HOKUYO, replace with Dingo-style JACKAL_LASER_TYPE
- add JACKAL_LASER2 for mounting a secondary laser without using the accessory fenders
- add JACKAL_LASER_3D for mounting a primary 3D lidar