### PR TITLE
Set the angle range for fender lasers

### DIFF
--- a/jackal_description/urdf/accessories.urdf.xacro
+++ b/jackal_description/urdf/accessories.urdf.xacro
@@ -187,6 +187,8 @@
       <xacro:hokuyo_ust10_mount
         prefix="front"
         parent_link="front_fender_accessory_link"
+        min_angle="${-pi/2}"
+        max_angle="${pi/2}"
         topic="$(optenv JACKAL_FRONT_LASER_TOPIC front/scan)">
         <origin xyz="0 0 0" rpy="0 0 0" />
       </xacro:hokuyo_ust10_mount>
@@ -198,6 +200,8 @@
       <xacro:hokuyo_ust10_mount
         prefix="rear"
         parent_link="rear_fender_accessory_link"
+        min_angle="${-pi/2}"
+        max_angle="${pi/2}"
         topic="$(optenv JACKAL_REAR_LASER_TOPIC rear/scan)">
         <origin xyz="0 0 0" rpy="0 0 0" />
       </xacro:hokuyo_ust10_mount>

--- a/jackal_description/urdf/accessories/hokuyo_ust10.urdf.xacro
+++ b/jackal_description/urdf/accessories/hokuyo_ust10.urdf.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="hokuyo_ust10_mount" params="prefix topic parent_link *origin">
+  <xacro:macro name="hokuyo_ust10_mount" params="prefix topic parent_link min_angle:=-2.35619 max_angle:=2.35619 *origin">
 
     <xacro:macro name="hokuyo_ust10" params="frame:=laser topic:=scan sample_size:=720 update_rate:=50
-               min_angle:=-2.35619 max_angle:=2.35619 min_range:=0.1 max_range:=30.0 robot_namespace:=/">
+               min_angle:=${min_angle} max_angle:=${max_angle} min_range:=0.1 max_range:=30.0 robot_namespace:=/">
       <link name="${frame}">
         <inertial>
           <mass value="1.1" />


### PR DESCRIPTION
Add the ability to specify the max/min angle of the UST10 in the URDF macro.  Set the angles to [-pi, pi] for the fender accessories to prevent them from seeing the robot's wheels & chassis.