### PR TITLE
Enable roslaunch_add_file_check when CATKIN_ENABLE_TESTING=true

### DIFF
--- a/jackal_control/CMakeLists.txt
+++ b/jackal_control/CMakeLists.txt
@@ -1,12 +1,15 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(jackal_control)
 
-find_package(catkin REQUIRED COMPONENTS roslaunch)
+find_package(catkin REQUIRED COMPONENTS)
 
 catkin_package()
 
-roslaunch_add_file_check(launch/control.launch)
-roslaunch_add_file_check(launch/teleop.launch)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/control.launch)
+  roslaunch_add_file_check(launch/teleop.launch)
+endif()
 
 install(DIRECTORY config launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/jackal_description/CMakeLists.txt
+++ b/jackal_description/CMakeLists.txt
@@ -1,12 +1,14 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(jackal_description)
 
-find_package(catkin REQUIRED COMPONENTS roslaunch)
+find_package(catkin REQUIRED COMPONENTS)
 
 catkin_package()
 
-roslaunch_add_file_check(launch/description.launch)
-
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/description.launch)
+endif()
 install(DIRECTORY meshes launch urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/jackal_navigation/CMakeLists.txt
+++ b/jackal_navigation/CMakeLists.txt
@@ -1,16 +1,19 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(jackal_navigation)
 
-find_package(catkin REQUIRED COMPONENTS roslaunch)
+find_package(catkin REQUIRED COMPONENTS)
 
 catkin_package()
 
-roslaunch_add_file_check(launch/include/amcl.launch)
-roslaunch_add_file_check(launch/amcl_demo.launch)
-roslaunch_add_file_check(launch/include/gmapping.launch)
-roslaunch_add_file_check(launch/gmapping_demo.launch)
-roslaunch_add_file_check(launch/include/move_base.launch)
-roslaunch_add_file_check(launch/odom_navigation_demo.launch)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/include/amcl.launch)
+  roslaunch_add_file_check(launch/amcl_demo.launch)
+  roslaunch_add_file_check(launch/include/gmapping.launch)
+  roslaunch_add_file_check(launch/gmapping_demo.launch)
+  roslaunch_add_file_check(launch/include/move_base.launch)
+  roslaunch_add_file_check(launch/odom_navigation_demo.launch)
+endif()
 
 install(
 DIRECTORY launch maps params


### PR DESCRIPTION
`roslaunch_add_file_check` needs CMake command "catkin_run_tests_target". "catkin_run_tests_target" is active when -DCATKIN_ENABLE_TESTING=true
It fixes 
```
#16 83.13   Unknown CMake command "catkin_run_tests_target".
#16 83.13 Call Stack (most recent call first):
#16 83.13   CMakeLists.txt:44 (roslaunch_add_file_check)
```
when using `catkin_make_isolated  -DCATKIN_ENABLE_TESTING=false`