### PR TITLE
Allow subst_value when loading JACKAL_CONFIG_EXTRAS

### DIFF
--- a/jackal_control/launch/control.launch
+++ b/jackal_control/launch/control.launch
@@ -34,7 +34,7 @@
   </node>
 
   <group if="$(optenv JACKAL_CONTROL_EXTRAS 0)" >
-    <rosparam command="load" file="$(env JACKAL_CONTROL_EXTRAS_PATH)" />
+    <rosparam command="load" file="$(env JACKAL_CONTROL_EXTRAS_PATH)" subst_value="true" />
   </group>
 
 </launch>


### PR DESCRIPTION
Set subst_value=true when loading the control_extras file to allow envar-defined configuration inside the file

This will help with setting up IndoorNav