### PR TITLE
WIP - Remove recursive variable definition of microstrain_enable

### DIFF
--- a/jackal_description/urdf/accessories.urdf.xacro
+++ b/jackal_description/urdf/accessories.urdf.xacro
@@ -30,7 +30,7 @@
     optional microstrain IMU's will be added to another frame, by default, "microstrain_link".
   -->
   <xacro:property name="microstrain_enable" value="$(optenv JACKAL_GX5_IMU 0)"/>
-  <xacro:property name="microstrain_enable" value="$(optenv JACKAL_IMU_MICROSTRAIN ${microstrain_enable})" lazy_eval="false"/>
+  <xacro:property name="microstrain_enable" value="$(optenv JACKAL_IMU_MICROSTRAIN 0)" lazy_eval="false"/>
   <xacro:if value="${microstrain_enable}">
     <xacro:property name="frame"  value="$(optenv JACKAL_IMU_MICROSTRAIN_LINK microstrain_link)"/>
   


### PR DESCRIPTION
The current syntax causes a recursive definition error of `microstrain_enable` on Melodic Jackals, as shown on a customer's Melodic Jackal. I had to replace the current syntax with the new change to get past the error; however, if the default value of `JACKAL_IMU_MICROSTRAIN` should be something other than 0, please let me know and I will update this PR.

```
xacro: in-order processing became default in ROS Melodic. You can drop the option.
xacro:property: unknown attribute(s): lazy_eval
when processing file: /opt/ros/melodic/share/jackal_description/urdf/accessories.urdf.xacro
included from: /opt/ros/melodic/share/jackal_description/urdf/jackal.urdf.xacro
recursive variable definition: microstrain_enable -> microstrain_enable 
when evaluating expression 'microstrain_enable' 
when evaluating expression 'microstrain_enable'
when processing file: /opt/ros/melodic/share/jackal_description/urdf/accessories.urdf.xacro
included from: /opt/ros/melodic/share/jackal_description/urdf/jackal.urdf.xacro
No handlers could be found for logger "roslaunch"
RLException: while processing /etc/ros/melodic/ros.d/base.launch:
while processing /opt/ros/melodic/share/jackal_description/launch/description.launch:
Invalid <param> tag: Cannot load command parameter [robot_description]: command [['/opt/ros/melodic/lib/jackal_description/env_run', '/opt/ros/melodic/share/jackal_description/urdf/configs/base', '/opt/ros/melodic/lib/xacro/xacro', '/opt/ros/melodic/share/jackal_description/urdf/jackal.urdf.xacro', '--inorder']] returned with code [2]. 

Param xml is <param command="$(find jackal_description)/scripts/$(arg env_runner)                     $(find jackal_description)/urdf/configs/$(arg config)                     $(find xacro)/xacro $(find jackal_description)/urdf/jackal.urdf.xacro                     --inorder" name="robot_description"/>
The traceback for the exception was written to the log file
```