### PR TITLE
Added sim support

### DIFF
--- a/jackal_control/launch/control.launch.py
+++ b/jackal_control/launch/control.launch.py
@@ -1,9 +1,11 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, GroupAction
+from launch.conditions import UnlessCondition
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.parameter_descriptions import ParameterValue
+
 
 def generate_launch_description():
 
@@ -38,6 +40,12 @@ def generate_launch_description():
             )
         ]
     )
+
+    is_sim = LaunchConfiguration('is_sim', default=False)
+
+    is_sim_arg = DeclareLaunchArgument(
+        'is_sim',
+        default_value=is_sim)
 
     robot_description_content = ParameterValue(
         Command(LaunchConfiguration('robot_description_command')),
@@ -77,6 +85,7 @@ def generate_launch_description():
                 'stdout': 'screen',
                 'stderr': 'screen',
             },
+            condition=UnlessCondition(is_sim)
         ),
 
         # Joint State Broadcaster
@@ -98,6 +107,7 @@ def generate_launch_description():
 
     ld = LaunchDescription()
     ld.add_action(robot_description_command_arg)
+    ld.add_action(is_sim_arg)
     ld.add_action(localization_group_action)
     ld.add_action(control_group_action)
     return ld

--- a/jackal_description/urdf/jackal.gazebo
+++ b/jackal_description/urdf/jackal.gazebo
@@ -1,40 +1,38 @@
 <?xml version="1.0"?>
 <robot>
+
   <gazebo>
-    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-      <robotNamespace>/</robotNamespace>
+    <plugin name="$(arg prefix)gazebo_ros2_control" filename="libgazebo_ros2_control.so">
+      <parameters>$(arg gazebo_controllers)</parameters>
     </plugin>
   </gazebo>
 
-  <gazebo>
-    <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
-      <robotNamespace>/</robotNamespace>
-      <updateRate>50.0</updateRate>
-      <bodyName>imu_link</bodyName>
-      <topicName>imu/data</topicName>
-      <accelDrift>0.005 0.005 0.005</accelDrift>
-      <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
-      <rateDrift>0.005 0.005 0.005 </rateDrift>
-      <rateGaussianNoise>0.005 0.005 0.005 </rateGaussianNoise>
-      <headingDrift>0.005</headingDrift>
-      <headingGaussianNoise>0.005</headingGaussianNoise>
-    </plugin>
+  <gazebo reference="$(arg prefix)imu_link">
+    <sensor name="$(arg prefix)imu_sensor" type="imu">
+    <plugin filename="libgazebo_ros_imu_sensor.so" name="$(arg prefix)imu_plugin">
+        <ros>
+          <namespace>$(arg prefix)</namespace>
+          <remapping>~/out:=imu/data_raw</remapping>
+        </ros>
+        <initial_orientation_as_reference>false</initial_orientation_as_reference>
+      </plugin>
+      <always_on>true</always_on>
+      <update_rate>100</update_rate>
+      <visualize>true</visualize>
+    </sensor>
   </gazebo>
 
-  <gazebo>
-    <plugin name="gps_controller" filename="libhector_gazebo_ros_gps.so">
-      <updateRate>40</updateRate>
-      <robotNamespace>/</robotNamespace>
-      <bodyName>navsat_link</bodyName>
-      <frameId>base_link</frameId>
-      <topicName>/navsat/fix</topicName>
-      <velocityTopicName>/navsat/vel</velocityTopicName>
-      <referenceLatitude>49.9</referenceLatitude>
-      <referenceLongitude>8.9</referenceLongitude>
-      <referenceHeading>0</referenceHeading>
-      <referenceAltitude>0</referenceAltitude>
-      <drift>0.0001 0.0001 0.0001</drift>
-    </plugin>
+  <gazebo reference="$(arg prefix)gps_link">
+    <sensor name="$(arg prefix)gps_sensor" type="gps">
+    <plugin filename="libgazebo_ros_gps_sensor.so" name="$(arg prefix)gps_plugin">
+        <ros>
+          <namespace>$(arg prefix)</namespace>
+          <remapping>~/out:=gps/data</remapping>
+        </ros>
+      </plugin>
+      <always_on>true</always_on>
+      <update_rate>10</update_rate>
+    </sensor>
   </gazebo>
 
   <gazebo reference="base_link">

--- a/jackal_description/urdf/jackal.urdf.xacro
+++ b/jackal_description/urdf/jackal.urdf.xacro
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <robot name="jackal" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:arg name="is_sim" default="false" />
-
+  <xacro:arg name="prefix" default="" />
+  <xacro:arg name="gazebo_controllers" default="$(find jackal_control)/config/control.yaml" />
   <xacro:property name="PI" value="3.1415926535897931" />
 
   <xacro:property name="wheelbase" value="0.262" />
@@ -251,6 +252,7 @@
     <origin xyz="${mount_spacing} 0 0" />
   </joint>
 
+  <!-- ROS2 controls -->
   <ros2_control name="jackal_hardware" type="system">
     <hardware>
       <xacro:if value="$(arg is_sim)">
@@ -284,7 +286,9 @@
   </ros2_control>
 
   <!-- Bring in simulation data for Gazebo. -->
-  <xacro:include filename="$(find jackal_description)/urdf/jackal.gazebo" />
+  <xacro:if value="$(arg is_sim)">
+    <xacro:include filename="$(find jackal_description)/urdf/jackal.gazebo" />
+  </xacro:if>
 
   <!-- Optional standard accessories, including their simulation data. The rendering
        of these into the final description is controlled by optenv variables, which


### PR DESCRIPTION
Launch `gazebo_ros2_control` instead of `ros2_control_node` when simulating.