### PR TITLE
[jackal_navigation] Switched from robot_radius to footprint.

### DIFF
--- a/jackal_navigation/config/nav2.yaml
+++ b/jackal_navigation/config/nav2.yaml
@@ -166,7 +166,7 @@ local_costmap:
       width: 3
       height: 3
       resolution: 0.025
-      robot_radius: 0.3
+      footprint: [[-0.21, -0.165], [-0.21, 0.165], [0.21, 0.165], [0.21, -0.165]]
       plugins: ["voxel_layer", "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
@@ -206,7 +206,7 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: True
-      robot_radius: 0.3
+      footprint: [[-0.21, -0.165], [-0.21, 0.165], [0.21, 0.165], [0.21, -0.165]]
       resolution: 0.05
       width: 20
       height: 20


### PR DESCRIPTION
Fixed for https://github.com/jackal/jackal/issues/138.