### PR TITLE
added outdoornav enable variable and hardware kit selector for urdf

### DIFF
--- a/jackal_description/package.xml
+++ b/jackal_description/package.xml
@@ -12,14 +12,15 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
+  <run_depend>cpr_onav_description</run_depend>
   <run_depend>flir_camera_description</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>urdf</run_depend>
-  <run_depend>xacro</run_depend>
   <run_depend>lms1xx</run_depend>
   <run_depend>pointgrey_camera_description</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
   <run_depend>sick_tim</run_depend>
+  <run_depend>urdf</run_depend>
   <run_depend>velodyne_description</run_depend>
+  <run_depend>xacro</run_depend>
 
   <export>
   </export>

--- a/jackal_description/urdf/jackal.urdf.xacro
+++ b/jackal_description/urdf/jackal.urdf.xacro
@@ -259,4 +259,14 @@
 
   <!-- Optional for Clearpath internal softwares -->
   <xacro:include filename="$(optenv CPR_URDF_EXTRAS empty.urdf)" />
+
+    <!-- OutdoorNav -->
+  <xacro:arg name="outdoornav_enabled"       default="$(optenv OUTDOORNAV_ENABLED 0)" />
+  <xacro:arg name="outdoornav_configuration" default="$(optenv OUTDOORNAV_CONFIGURATION standard)" />
+
+  <!-- OutdoorNav URDF Config -->
+  <xacro:if value="$(arg outdoornav_enabled)">
+    <xacro:include filename="$(find cpr_onav_description)/urdf/outdoornav_description.urdf.xacro" />
+    <xacro:outdoornav_sensors outdoornav_configuration="$(arg outdoornav_configuration)" />
+  </xacro:if>
 </robot>

--- a/jackal_description/urdf/jackal.urdf.xacro
+++ b/jackal_description/urdf/jackal.urdf.xacro
@@ -254,13 +254,7 @@
        default each one to off.-->
   <xacro:include filename="$(find jackal_description)/urdf/accessories.urdf.xacro" />
 
-  <!-- Optional custom includes. -->
-  <xacro:include filename="$(optenv JACKAL_URDF_EXTRAS empty.urdf)" />
-
-  <!-- Optional for Clearpath internal softwares -->
-  <xacro:include filename="$(optenv CPR_URDF_EXTRAS empty.urdf)" />
-
-    <!-- OutdoorNav -->
+  <!-- OutdoorNav -->
   <xacro:arg name="outdoornav_enabled"       default="$(optenv OUTDOORNAV_ENABLED 0)" />
   <xacro:arg name="outdoornav_configuration" default="$(optenv OUTDOORNAV_CONFIGURATION standard)" />
 
@@ -269,4 +263,11 @@
     <xacro:include filename="$(find cpr_onav_description)/urdf/outdoornav_description.urdf.xacro" />
     <xacro:outdoornav_sensors outdoornav_configuration="$(arg outdoornav_configuration)" />
   </xacro:if>
+
+  <!-- Optional custom includes. -->
+  <xacro:include filename="$(optenv JACKAL_URDF_EXTRAS empty.urdf)" />
+
+  <!-- Optional for Clearpath internal softwares -->
+  <xacro:include filename="$(optenv CPR_URDF_EXTRAS empty.urdf)" />
+
 </robot>


### PR DESCRIPTION
Added the option to extend the URDF with the OutdoorNav links. Including:

Starter Kit
Standard Kit
Custom
New dependency: cpr_onav_description