### PR TITLE
Mod: Set 'publish_cmd' param to true in jackal_control/config

### DIFF
--- a/jackal_control/config/control.yaml
+++ b/jackal_control/config/control.yaml
@@ -11,6 +11,9 @@ jackal_velocity_controller:
   twist_covariance_diagonal: [0.001, 0.001, 0.001, 1000000.0, 1000000.0, 0.03]
   cmd_vel_timeout: 0.25
 
+  # Publish final output cmd_vel to /jackal_velocity_controller/cmd_vel_out
+  publish_cmd: true
+
   k_l: 0.1
   k_r: 0.1
 


### PR DESCRIPTION
- With this change the diff drive controller will output the final cmd_vel to /jackal_velocity_controller/cmd_vel_out after any filters are applied (e.g., speed/acceleration limits)