### PR TITLE
EKF IMU removed yaw position

### DIFF
--- a/jackal_control/launch/control.launch
+++ b/jackal_control/launch/control.launch
@@ -13,12 +13,12 @@
     </node>
 
     <group if="$(optenv JACKAL_IMU_MICROSTRAIN 0)">
-      <!-- Optionally load the configuration for the Microstrain-family IMU -->
       <rosparam>
+        <!-- Optionally load the configuration for the Microstrain-family IMU -->
         ekf_localization:
           imu1: microstrain/imu/data
           imu1_config: [false, false, false,
-                      true, true, true,
+                      true, true, false,
                       false, false, false,
                       true, true, true,
                       false, false, false]


### PR DESCRIPTION
By default, when a microstrain is added, the IMU data is added as a secondary sensor to the EKF localization node. 

In our standard built in IMU, we disable the absolute yaw published by the IMU. If it is not enabled, we notice that the resulting EKF causes the robot odometry to appear as if the robot is moving in the opposite direction. 

